### PR TITLE
スポンシブ対応などで、mixinが後ろに来ることがあるので、mixins-before-declarationsを無効に

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -46,7 +46,7 @@ rules:
   force-pseudo-nesting: 0
   force-attribute-nesting: 0
   no-color-literals: 0
-  mixins-before-declarations: 2
+  mixins-before-declarations: 0
   extends-before-declarations: 2
   no-vendor-prefixes: 2
   pseudo-element: 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fourdigit/sasslint-config-fourdigit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fourdigit/sasslint-config-fourdigit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SassLint shareable config",
   "keywords": [
     "sasslint",


### PR DESCRIPTION
スポンシブ対応などで、mixinが後ろに来ることがあるので、mixins-before-declarationsを無効に